### PR TITLE
NEXUS-14219 Allow PUT multipart

### DIFF
--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/DirectJNgineServlet.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/DirectJNgineServlet.java
@@ -39,8 +39,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload.FileUploadBase;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.commons.fileupload.servlet.ServletRequestContext;
 import org.apache.log4j.Logger;
 import org.apache.log4j.NDC;
 
@@ -547,7 +549,7 @@ public class DirectJNgineServlet extends HttpServlet {
     else if( StringUtils.startsWithCaseInsensitive( contentType, "application/x-www-form-urlencoded") && request.getMethod().equalsIgnoreCase("post")) {
       return RequestType.FORM_SIMPLE_POST;
     }
-    else if( ServletFileUpload.isMultipartContent(request)) {
+    else if( isMultipartContent(request)) {
       return RequestType.FORM_UPLOAD_POST;
     }
     else if( RequestRouter.isSourceRequest(pathInfo)) {
@@ -558,6 +560,15 @@ public class DirectJNgineServlet extends HttpServlet {
       RequestException ex = RequestException.forRequestFormatNotRecognized();
       logger.error( "Error during file uploader: " + ex.getMessage() + "\nAdditional request information: " + requestInfo, ex );
       throw ex;
+    }
+  }
+
+  public static final boolean isMultipartContent(HttpServletRequest request) {
+    if (!("POST".equalsIgnoreCase(request.getMethod()) || "PUT".equalsIgnoreCase(request.getMethod()))) {
+      return false;
+    }
+    else {
+      return FileUploadBase.isMultipartContent(new ServletRequestContext(request));
     }
   }
 

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/DirectJNgineServlet.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/DirectJNgineServlet.java
@@ -534,7 +534,7 @@ public class DirectJNgineServlet extends HttpServlet {
     return result;
   }
   
-  private static RequestType getFromRequestContentType( HttpServletRequest request ) {
+  static RequestType getFromRequestContentType( HttpServletRequest request ) {
     assert request != null;
     
     String contentType = request.getContentType();

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/DirectJNgineServlet.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/DirectJNgineServlet.java
@@ -563,13 +563,9 @@ public class DirectJNgineServlet extends HttpServlet {
     }
   }
 
-  public static final boolean isMultipartContent(HttpServletRequest request) {
-    if (!("POST".equalsIgnoreCase(request.getMethod()) || "PUT".equalsIgnoreCase(request.getMethod()))) {
-      return false;
-    }
-    else {
-      return FileUploadBase.isMultipartContent(new ServletRequestContext(request));
-    }
+  private static boolean isMultipartContent(HttpServletRequest request) {
+    return ("POST".equalsIgnoreCase(request.getMethod()) || "PUT".equalsIgnoreCase(request.getMethod())) &&
+        FileUploadBase.isMultipartContent(new ServletRequestContext(request));
   }
 
   @Override

--- a/directjngine/src/test/java/com/softwarementors/extjs/djn/servlet/DirectJNgineServletTest.java
+++ b/directjngine/src/test/java/com/softwarementors/extjs/djn/servlet/DirectJNgineServletTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018-present Sonatype, Inc.
+ *
+ * This file is part of DirectJNgine.
+ *
+ * DirectJNgine is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License.
+ *
+ * Commercial use is permitted to the extent that the code/component(s)
+ * do NOT become part of another Open Source or Commercially developed
+ * licensed development library or toolkit without explicit permission.
+ *
+ * DirectJNgine is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DirectJNgine.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * This software uses the ExtJs library (http://extjs.com), which is
+ * distributed under the GPL v3 license (see http://extjs.com/license).
+ */
+package com.softwarementors.extjs.djn.servlet;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.softwarementors.extjs.djn.router.RequestType;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class DirectJNgineServletTest
+{
+  private static final String MULTIPART = "multipart/";
+
+  private HttpServletRequest request;
+  
+  @BeforeTest
+  public void setup() {
+    request = mock(HttpServletRequest.class);
+    
+    when(request.getPathInfo()).thenReturn("path");
+  }
+  
+  @Test
+  public void getFromRequestContentTypeReturnFormUploadWhenMultipartPut() {
+    when(request.getContentType()).thenReturn("multipart/");
+    when(request.getMethod()).thenReturn("PUT");
+    
+    RequestType type = DirectJNgineServlet.getFromRequestContentType(request);
+
+    assertEquals(type, RequestType.FORM_UPLOAD_POST);
+  }
+
+  @Test
+  public void getFromRequestContentTypeReturnFormUploadWhenMultipartPost() {
+    when(request.getContentType()).thenReturn(MULTIPART);
+    when(request.getMethod()).thenReturn("POST");
+
+    RequestType type = DirectJNgineServlet.getFromRequestContentType(request);
+
+    assertEquals(type, RequestType.FORM_UPLOAD_POST);
+  }
+}


### PR DESCRIPTION
Nuget uses PUT for multipart uploads which we've now enabled in NXRM as part of 
https://github.com/sonatype/nexus-internal/pull/3864. This PR allows the same behaviour in the DirectJngine. 

CI: https://jenkins.zion.aws.s/job/nxrm/job/libraries/job/directjngine-feature/job/NEXUS-14219_allow_put_multipart/2/