### PR TITLE
NEXUS-29025: prevent reflective poll error response

### DIFF
--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/gson/DefaultGsonBuilderConfigurator.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/gson/DefaultGsonBuilderConfigurator.java
@@ -32,11 +32,14 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.softwarementors.extjs.djn.config.GlobalConfiguration;
+import com.softwarementors.extjs.djn.router.processor.ServerExceptionInformation.ExceptionInformation;
+import com.softwarementors.extjs.djn.router.processor.poll.PollErrorResponseData;
 
 public class DefaultGsonBuilderConfigurator implements GsonBuilderConfigurator {
 
@@ -74,6 +77,48 @@ public class DefaultGsonBuilderConfigurator implements GsonBuilderConfigurator {
     }
   }
 
+  private static class PollErrorResponseDataSerializer implements JsonSerializer<PollErrorResponseData> {
+    @Override
+    public JsonElement serialize(
+        final PollErrorResponseData src,
+        final Type typeOfSrc,
+        final JsonSerializationContext context)
+    {
+      assert src != null;
+      assert typeOfSrc != null;
+      assert context != null;
+
+      JsonObject result = new JsonObject();
+      result.addProperty("message", clean(src.message));
+      result.addProperty("where", clean(src.where));
+      result.add("serverException", context.serialize(src.serverException));
+      return result;
+    }
+  }
+
+  private static class ExceptionInformationSerializer implements JsonSerializer<ExceptionInformation> {
+    @Override
+    public JsonElement serialize(
+        final ExceptionInformation src,
+        final Type typeOfSrc,
+        final JsonSerializationContext context)
+    {
+      assert src != null;
+      assert typeOfSrc != null;
+      assert context != null;
+
+      JsonObject result = new JsonObject();
+      result.addProperty("type", clean(src.type));
+      result.addProperty("message", clean(src.message));
+      result.addProperty("where", clean(src.where));
+      return result;
+    }
+  }
+
+  private static String clean(final String toClean) {
+    return toClean.replaceAll("[^a-zA-Z\\d\\s]", "*");
+  }
+
   public void configure(GsonBuilder builder, GlobalConfiguration configuration) {
     assert builder != null;
     assert configuration != null;
@@ -86,6 +131,8 @@ public class DefaultGsonBuilderConfigurator implements GsonBuilderConfigurator {
     
     builder.registerTypeAdapter( Date.class, new DateDeserializer());
     builder.registerTypeAdapter( Date.class, new DateSerializer());
+    builder.registerTypeAdapter(PollErrorResponseData.class, new PollErrorResponseDataSerializer());
+    builder.registerTypeAdapter(ExceptionInformation.class, new ExceptionInformationSerializer());
   }
 
 }

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/gson/DefaultGsonBuilderConfigurator.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/gson/DefaultGsonBuilderConfigurator.java
@@ -116,7 +116,7 @@ public class DefaultGsonBuilderConfigurator implements GsonBuilderConfigurator {
   }
 
   private static String clean(final String toClean) {
-    return toClean.replaceAll("[^a-zA-Z\\d\\s]", "*");
+    return toClean.replaceAll("[^\\w\\s.\\-:/]", "*");
   }
 
   public void configure(GsonBuilder builder, GlobalConfiguration configuration) {

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/ErrorResponseData.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/ErrorResponseData.java
@@ -32,11 +32,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public abstract class ErrorResponseData extends ResponseData {
   @edu.umd.cs.findbugs.annotations.SuppressWarnings( value="URF_UNREAD_FIELD", justification="Passed to JSON side only")
-  @NonNull /* package */ String message;
+  @NonNull public String message;
   @edu.umd.cs.findbugs.annotations.SuppressWarnings( value="URF_UNREAD_FIELD", justification="Passed to JSON side only")
-  @NonNull /* package */ String where;
+  @NonNull public String where;
   @edu.umd.cs.findbugs.annotations.SuppressWarnings( value="URF_UNREAD_FIELD", justification="Passed to JSON side only")
-  @NonNull /* package */ ServerExceptionInformation serverException;
+  @NonNull public ServerExceptionInformation serverException;
   /*
   @NonNull private String serverExceptionMessage;
   @NonNull private String serverExceptionType;

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/ExceptionInformation.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/ExceptionInformation.java
@@ -2,8 +2,8 @@ package com.softwarementors.extjs.djn.router.processor;
 
 
 public class ExceptionInformation {
-  /* package */ String exceptionClass;
-  /* package */ String message;
+  public String exceptionClass;
+  public String message;
   // Future development: we may have an exception handler that allows
   // us to register exception processors to pass extra data
   // private Map<String, Object> extraData = new HashMap<String,Object>();

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/ServerExceptionInformation.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/ServerExceptionInformation.java
@@ -8,7 +8,7 @@ import com.softwarementors.extjs.djn.ExceptionUtils;
 /* Information about unexpected server exception, passed
  * to the Javascript side
  */
-/* package */ class ServerExceptionInformation {
+public class ServerExceptionInformation {
    
   /* package */ ExceptionInformation rootException;
   /* package */ ExceptionInformation exception;
@@ -25,13 +25,13 @@ import com.softwarementors.extjs.djn.ExceptionUtils;
     this.rootException = this.exceptions.get(this.exceptions.size()-1);
   }
   
-  /* package */ static class ExceptionInformation {
+  public static class ExceptionInformation {
     @edu.umd.cs.findbugs.annotations.SuppressWarnings( value="URF_UNREAD_FIELD", justification="Passed to JSON side only")
-    /* package */ String type;
+    public String type;
     @edu.umd.cs.findbugs.annotations.SuppressWarnings( value="URF_UNREAD_FIELD", justification="Passed to JSON side only")
-    /* package */ String message;
+    public String message;
     @edu.umd.cs.findbugs.annotations.SuppressWarnings( value="URF_UNREAD_FIELD", justification="Passed to JSON side only")
-    /* package */ String where;
+    public String where;
     // Future development: we may have an exception handler that allows
     // us to register exception processors to pass extra data
     // private Map<String, Object> extraData = new HashMap<String,Object>();

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/poll/PollErrorResponseData.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/poll/PollErrorResponseData.java
@@ -31,7 +31,7 @@ public class PollErrorResponseData extends ErrorResponseData {
   // No additional code required: we have this class because it reflects a 
   // domain concept, even if no additional code is needed for it 
 
-  /* package */ PollErrorResponseData(Throwable exception, boolean debugOn) {
+  public PollErrorResponseData(Throwable exception, boolean debugOn) {
     super(exception, debugOn);    
   }
 }

--- a/directjngine/src/test/java/com/softwarementors/extjs/djn/gson/DefaultGsonBuilderConfiguratorTest.java
+++ b/directjngine/src/test/java/com/softwarementors/extjs/djn/gson/DefaultGsonBuilderConfiguratorTest.java
@@ -26,7 +26,6 @@ package com.softwarementors.extjs.djn.gson;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
 import com.softwarementors.extjs.djn.config.GlobalConfiguration;
 import com.softwarementors.extjs.djn.router.processor.poll.PollErrorResponseData;
 import org.testng.annotations.BeforeTest;
@@ -53,8 +52,19 @@ public class DefaultGsonBuilderConfiguratorTest
 
   @Test
   public void testPollErrorResponseDataSerializer() {
-    PollErrorResponseData pollErrorResponseData = new PollErrorResponseData(new RuntimeException("uhoh"), false);
+    //The <,>,\,",',[,],{,},(,) chars should all be excluded
+    PollErrorResponseData pollErrorResponseData =
+        new PollErrorResponseData(new RuntimeException("uhoh<sometag><someendtag/>\"'/\\{}[]()"), false);
     String jsonString = gson.toJson(pollErrorResponseData);
-    assertThat(jsonString, is("{\"message\":\"RuntimeException* uhoh\",\"where\":\"\",\"serverException\":{\"rootException\":{\"type\":\"java*lang*RuntimeException\",\"message\":\"uhoh\",\"where\":\"\"},\"exception\":{\"type\":\"java*lang*RuntimeException\",\"message\":\"uhoh\",\"where\":\"\"},\"exceptions\":[{\"type\":\"java*lang*RuntimeException\",\"message\":\"uhoh\",\"where\":\"\"}]}}"));
+    assertThat(jsonString, is(expectedResponse()));
+  }
+
+  private String expectedResponse() {
+    return "{\"message\":\"RuntimeException: uhoh*sometag**someendtag/***/*******\",\"where\":\"\"," +
+        "\"serverException\":{\"rootException\":{\"type\":\"java.lang.RuntimeException\"," +
+        "\"message\":\"uhoh*sometag**someendtag/***/*******\",\"where\":\"\"},\"exception\":{" +
+        "\"type\":\"java.lang.RuntimeException\",\"message\":\"uhoh*sometag**someendtag/***/*******\"," +
+        "\"where\":\"\"},\"exceptions\":[{\"type\":\"java.lang.RuntimeException\"," +
+        "\"message\":\"uhoh*sometag**someendtag/***/*******\",\"where\":\"\"}]}}";
   }
 }

--- a/directjngine/src/test/java/com/softwarementors/extjs/djn/gson/DefaultGsonBuilderConfiguratorTest.java
+++ b/directjngine/src/test/java/com/softwarementors/extjs/djn/gson/DefaultGsonBuilderConfiguratorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018-present Sonatype, Inc.
+ *
+ * This file is part of DirectJNgine.
+ *
+ * DirectJNgine is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License.
+ *
+ * Commercial use is permitted to the extent that the code/component(s)
+ * do NOT become part of another Open Source or Commercially developed
+ * licensed development library or toolkit without explicit permission.
+ *
+ * DirectJNgine is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DirectJNgine.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * This software uses the ExtJs library (http://extjs.com), which is
+ * distributed under the GPL v3 license (see http://extjs.com/license).
+ */
+package com.softwarementors.extjs.djn.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.softwarementors.extjs.djn.config.GlobalConfiguration;
+import com.softwarementors.extjs.djn.router.processor.poll.PollErrorResponseData;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class DefaultGsonBuilderConfiguratorTest
+{
+  private DefaultGsonBuilderConfigurator underTest;
+
+  private Gson gson;
+
+  @BeforeTest
+  public void setup() {
+    underTest = new DefaultGsonBuilderConfigurator();
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    GlobalConfiguration globalConfiguration = mock(GlobalConfiguration.class);
+    underTest.configure(gsonBuilder, globalConfiguration);
+    gson = gsonBuilder.create();
+  }
+
+  @Test
+  public void testPollErrorResponseDataSerializer() {
+    PollErrorResponseData pollErrorResponseData = new PollErrorResponseData(new RuntimeException("uhoh"), false);
+    String jsonString = gson.toJson(pollErrorResponseData);
+    assertThat(jsonString, is("{\"message\":\"RuntimeException* uhoh\",\"where\":\"\",\"serverException\":{\"rootException\":{\"type\":\"java*lang*RuntimeException\",\"message\":\"uhoh\",\"where\":\"\"},\"exception\":{\"type\":\"java*lang*RuntimeException\",\"message\":\"uhoh\",\"where\":\"\"},\"exceptions\":[{\"type\":\"java*lang*RuntimeException\",\"message\":\"uhoh\",\"where\":\"\"}]}}"));
+  }
+}


### PR DESCRIPTION
Will mask most non typical chars in the reponse with `*`, so even though we aren't vulnerable to the attack noted by user, this will make sure we aren't flagged any longer

https://issues.sonatype.org/browse/NEXUS-29025
https://jenkins.ci.sonatype.dev/job/nxrm/job/libraries/job/directjngine-feature/job/NEXUS-29025_prevent_reflective_response/1/