### PR TITLE
Fix incorrect file name regex logic

### DIFF
--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/jscodegen/CodeFileGenerator.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/jscodegen/CodeFileGenerator.java
@@ -167,7 +167,7 @@ public class CodeFileGenerator {
     return false;
   }
 
-  private static String getDebugFileName( String file ) {
+  protected static String getDebugFileName( String file ) {
     return file.replaceFirst( ".js$" , "-debug.js" );
   }
 }

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/jscodegen/CodeFileGenerator.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/jscodegen/CodeFileGenerator.java
@@ -166,9 +166,13 @@ public class CodeFileGenerator {
     }
     return false;
   }
-  
+
   private static String getDebugFileName( String file ) {
-    String result = file.replace( ".js", "-debug.js");
-    return result;
+    int extensionIndex = file.lastIndexOf( ".js" );
+
+    if ( extensionIndex != -1 && file.endsWith(".js") ) {
+      return file.substring(0, extensionIndex) + "-debug.js";
+    }
+    return file;
   }
 }

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/jscodegen/CodeFileGenerator.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/jscodegen/CodeFileGenerator.java
@@ -168,11 +168,6 @@ public class CodeFileGenerator {
   }
 
   private static String getDebugFileName( String file ) {
-    int extensionIndex = file.lastIndexOf( ".js" );
-
-    if ( extensionIndex != -1 && file.endsWith(".js") ) {
-      return file.substring(0, extensionIndex) + "-debug.js";
-    }
-    return file;
+    return file.replaceFirst( ".js$" , "-debug.js" );
   }
 }

--- a/directjngine/src/test/java/com/softwarementors/extjs/djn/jscodegen/CodeFileGeneratorTest.java
+++ b/directjngine/src/test/java/com/softwarementors/extjs/djn/jscodegen/CodeFileGeneratorTest.java
@@ -1,0 +1,34 @@
+package com.softwarementors.extjs.djn.jscodegen;
+
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+
+import static org.testng.Assert.*;
+
+public class CodeFileGeneratorTest {
+
+    private String getDebugFileName(String file) {
+        try {
+            Method method = CodeFileGenerator.class.getDeclaredMethod("getDebugFileName", String.class);
+            method.setAccessible(true);
+            Object result = method.invoke(null, file);
+            return (String) result;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "";
+        }
+    }
+
+    @Test
+    public void getDebugFileNameTest() {
+        assertEquals(
+                "john.jspiner",
+                getDebugFileName("john.jspiner")
+        );
+        assertEquals(
+                "app-debug.js",
+                getDebugFileName("app.js")
+        );
+    }
+}

--- a/directjngine/src/test/java/com/softwarementors/extjs/djn/jscodegen/CodeFileGeneratorTest.java
+++ b/directjngine/src/test/java/com/softwarementors/extjs/djn/jscodegen/CodeFileGeneratorTest.java
@@ -2,33 +2,19 @@ package com.softwarementors.extjs.djn.jscodegen;
 
 import org.testng.annotations.Test;
 
-import java.lang.reflect.Method;
-
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 public class CodeFileGeneratorTest {
-
-    private String getDebugFileName(String file) {
-        try {
-            Method method = CodeFileGenerator.class.getDeclaredMethod("getDebugFileName", String.class);
-            method.setAccessible(true);
-            Object result = method.invoke(null, file);
-            return (String) result;
-        } catch (Exception e) {
-            e.printStackTrace();
-            return "";
-        }
-    }
 
     @Test
     public void getDebugFileNameTest() {
         assertEquals(
                 "john.jspiner",
-                getDebugFileName("john.jspiner")
+                CodeFileGenerator.getDebugFileName("john.jspiner")
         );
         assertEquals(
                 "app-debug.js",
-                getDebugFileName("app.js")
+                CodeFileGenerator.getDebugFileName("app.js")
         );
     }
 }

--- a/directjngine/src/test/java/com/softwarementors/extjs/djn/jscodegen/CodeFileGeneratorTest.java
+++ b/directjngine/src/test/java/com/softwarementors/extjs/djn/jscodegen/CodeFileGeneratorTest.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright 2018-present Sonatype, Inc.
+ *
+ * This file is part of DirectJNgine.
+ *
+ * DirectJNgine is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License.
+ *
+ * Commercial use is permitted to the extent that the code/component(s)
+ * do NOT become part of another Open Source or Commercially developed
+ * licensed development library or toolkit without explicit permission.
+ *
+ * DirectJNgine is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DirectJNgine.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * This software uses the ExtJs library (http://extjs.com), which is
+ * distributed under the GPL v3 license (see http://extjs.com/license).
+ */
 package com.softwarementors.extjs.djn.jscodegen;
 
 import org.testng.annotations.Test;
@@ -8,13 +32,7 @@ public class CodeFileGeneratorTest {
 
     @Test
     public void getDebugFileNameTest() {
-        assertEquals(
-                "john.jspiner",
-                CodeFileGenerator.getDebugFileName("john.jspiner")
-        );
-        assertEquals(
-                "app-debug.js",
-                CodeFileGenerator.getDebugFileName("app.js")
-        );
+        assertEquals( "john.jspiner" , CodeFileGenerator.getDebugFileName( "john.jspiner" ) );
+        assertEquals( "app-debug.js" , CodeFileGenerator.getDebugFileName( "app.js" ) );
     }
 }


### PR DESCRIPTION
When I run [nexus](https://www.sonatype.com/products/repository-oss) with `nexus run`, I got the following error.

> Caused by: java.io.IOException: Directory '/Users/smith-debug.jspiner/nexus-3.34.1-01-mac/sonatype-work/nexus3/tmp/nexus-extdirect' could not be created
	at org.apache.commons.io.FileUtils.openOutputStream(FileUtils.java:2436)
	at org.apache.commons.io.FileUtils.writeStringToFile(FileUtils.java:3356)
	at org.apache.commons.io.FileUtils.writeStringToFile(FileUtils.java:3305)

My user name is `smith.jspiner` and file path is `/Users/smith.jspiner/nexus-.....`. 
But strangely, nexus was trying with `/Users/smith-debug.jspiner/nexus-....`. 😭 

When I checked the source code, there was an error in changing the file name for debug.

I modified the regex logic and added the test code. 
Please review it. 🙏 