### PR TITLE
ci: update config to point to 'main' as default branch

### DIFF
--- a/jenkins/Jenkinsfile-build
+++ b/jenkins/Jenkinsfile-build
@@ -2,6 +2,7 @@ library('private-pipeline-library')
 library('jenkins-shared')
 
 mavenSnapshotPipeline(performSonarAnalysis: true,
+    deployBranch: 'main',
     mavenVersion: 'Maven 3.6.x',
     onSuccess: { build, env ->
       notifyChat(env: env, currentBuild: build, room: 'nxrm-notifications')


### PR DESCRIPTION
Updated configuration per https://docs.sonatype.com/display/CDI/Maven+Shared+Pipelines#MavenSharedPipelines-deployBranch. The release Jenkinsfile does not need a change, but I believe https://jenkins.ci.sonatype.dev/job/nxrm/job/libraries/job/directjngine-release/ will need a configuration update to release from main.