### PR TITLE
BNR-1230 Publish to RSC

### DIFF
--- a/jenkins/Jenkinsfile-release
+++ b/jenkins/Jenkinsfile-release
@@ -3,6 +3,7 @@ library('jenkins-shared')
 
 mavenReleasePipeline(
     mavenVersion: 'Maven 3.6.x',
+    mavenSettingsFile: 'rsc-private-settings',
     onSuccess: { build, env ->
       notifyChat(env: env, currentBuild: build, room: 'nxrm-notifications')
     },


### PR DESCRIPTION
Jira: https://sonatype.atlassian.net/browse/BNR-1230
Jenkins: https://jenkins.ci.sonatype.dev/job/nxrm/job/libraries/job/directjngine-feature/job/BNR-1230-publish-to-rsc/

According to this [doc](https://sonatype.atlassian.net/wiki/spaces/BNR/pages/128024679/Opt-In+Publishing+Maven+Releases+to+repo.sonatype.com), this is the only change needed. 