### PR TITLE
NEXUS-49179: prep for Java EE 10

### DIFF
--- a/directjngine-demo/pom.xml
+++ b/directjngine-demo/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonatype.directjngine</groupId>
     <artifactId>directjngine-parent</artifactId>
-	<version>2.2.11-SNAPSHOT</version>
+	<version>2.3.0-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -30,8 +30,8 @@
   </licenses>
 
   <properties>
-    <maven.compiler.source>1.5</maven.compiler.source>
-    <maven.compiler.target>1.5</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -49,9 +49,9 @@
     -->
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.0.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/directjngine-demo/src/main/java/com/softwarementors/extjs/djn/demo/FormPostDemo.java
+++ b/directjngine-demo/src/main/java/com/softwarementors/extjs/djn/demo/FormPostDemo.java
@@ -28,7 +28,7 @@ package com.softwarementors.extjs.djn.demo;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload2.core.FileItem;
 import org.apache.commons.io.IOUtils;
 
 import com.softwarementors.extjs.djn.StringBuilderUtils;
@@ -42,7 +42,7 @@ public class FormPostDemo {
   }
   
   @DirectFormPostMethod
-  public Result djnform_handleSubmit( Map<String, String> formParameters, Map<String, FileItem> fileFields ) throws IOException  {
+  public Result djnform_handleSubmit( Map<String, String> formParameters, Map<String, FileItem<?>> fileFields ) throws IOException  {
     assert formParameters != null; 
     assert fileFields != null; 
 
@@ -57,9 +57,9 @@ public class FormPostDemo {
     }
     
     fieldNamesAndValues.append( "<p></p><p>FILE fields:</p>" );
-    for( Map.Entry<String,FileItem> entry : fileFields.entrySet() ) {
+    for( Map.Entry<String,FileItem<?>> entry : fileFields.entrySet() ) {
       String fieldName = entry.getKey();
-      FileItem fileItem = entry.getValue();
+      FileItem<?> fileItem = entry.getValue();
       result.fileContents = IOUtils.toString( fileItem.getInputStream() );
       fileItem.getInputStream().close();
       StringBuilderUtils.appendAll( fieldNamesAndValues, "<b>", fieldName, "</b>:" );

--- a/directjngine-demo/src/main/java/com/softwarementors/extjs/djn/demo/Profile.java
+++ b/directjngine-demo/src/main/java/com/softwarementors/extjs/djn/demo/Profile.java
@@ -28,7 +28,7 @@ package com.softwarementors.extjs.djn.demo;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload2.core.FileItem;
 
 import com.softwarementors.extjs.djn.config.annotations.DirectFormPostMethod;
 import com.softwarementors.extjs.djn.config.annotations.DirectMethod;
@@ -111,7 +111,7 @@ public class Profile {
   }
   
   @DirectFormPostMethod
-  public SubmitResult updateBasicInfo( Map<String, String> formParameters, Map<String, FileItem> fileFields ) {
+  public SubmitResult updateBasicInfo( Map<String, String> formParameters, Map<String, FileItem<?>> fileFields ) {
     assert formParameters != null;
     assert fileFields != null;
     

--- a/directjngine-demo/src/main/java/com/softwarementors/extjs/djn/test/FormTest.java
+++ b/directjngine-demo/src/main/java/com/softwarementors/extjs/djn/test/FormTest.java
@@ -27,13 +27,13 @@ package com.softwarementors.extjs.djn.test;
 
 import java.util.Map;
 
-import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload2.core.FileItem;
 
 import com.softwarementors.extjs.djn.config.annotations.DirectFormPostMethod;
 
 public class FormTest {
 
-  public OkResult djnform_test_formPostForNonAnnotatedMethod( Map<String, String> formParameters, Map<String, FileItem> fileFields )  {
+  public OkResult djnform_test_formPostForNonAnnotatedMethod( Map<String, String> formParameters, Map<String, FileItem<?>> fileFields )  {
     assert formParameters != null;
     assert fileFields != null;
 
@@ -50,7 +50,7 @@ public class FormTest {
   }
   
   @DirectFormPostMethod
-  public OkResult djnform_test_handleForm( Map<String, String> formParameters, Map<String, FileItem> fileFields )  {
+  public OkResult djnform_test_handleForm( Map<String, String> formParameters, Map<String, FileItem<?>> fileFields )  {
     assert formParameters != null;
     assert fileFields != null;
 
@@ -64,7 +64,7 @@ public class FormTest {
   }
 
   @DirectFormPostMethod
-  public OkResult test_handleFormWithBaseParams( Map<String, String> formParameters, Map<String, FileItem> fileFields )  {
+  public OkResult test_handleFormWithBaseParams( Map<String, String> formParameters, Map<String, FileItem<?>> fileFields )  {
     assert formParameters != null;
     assert fileFields != null;
 
@@ -81,7 +81,7 @@ public class FormTest {
   @DirectFormPostMethod
   @edu.umd.cs.findbugs.annotations.SuppressWarnings( value="SIC_INNER_SHOULD_BE_STATIC_ANON", 
     justification="MyServerException is never used outside of this method: making it an static inner class will obscure that")
-  public OkResult djnform_test_handleFormCausingServerException( Map<String, String> formParameters, Map<String, FileItem> fileFields ) {
+  public OkResult djnform_test_handleFormCausingServerException( Map<String, String> formParameters, Map<String, FileItem<?>> fileFields ) {
     assert formParameters != null;
     assert fileFields != null;
 
@@ -94,7 +94,7 @@ public class FormTest {
   
 /*  
   @DirectFormPostMethod
-  public int test_handleFormWithMultivaluedItem( Map<String, String> formParameters, Map<String, FileItem> fileFields )  {
+  public int test_handleFormWithMultivaluedItem( Map<String, String> formParameters, Map<String, FileItem<?>> fileFields )  {
     assert formParameters != null;
     assert fileFields != null;
 

--- a/directjngine-demo/src/main/java/com/softwarementors/extjs/djn/test/ManualFormUploadSupportTest.java
+++ b/directjngine-demo/src/main/java/com/softwarementors/extjs/djn/test/ManualFormUploadSupportTest.java
@@ -28,7 +28,7 @@ package com.softwarementors.extjs.djn.test;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload2.core.FileItem;
 import org.apache.commons.io.IOUtils;
 
 import com.softwarementors.extjs.djn.config.annotations.DirectFormPostMethod;
@@ -50,13 +50,13 @@ public class ManualFormUploadSupportTest {
   }
   
   @DirectFormPostMethod
-  public Result djnform_test_sendFilesManually( Map<String, String> formParameters, Map<String, FileItem> fileFields )  {
+  public Result djnform_test_sendFilesManually( Map<String, String> formParameters, Map<String, FileItem<?>> fileFields )  {
     assert formParameters != null;
     assert fileFields != null;
 
     Result r = new Result();
-    FileItem file1 = fileFields.get( "fileUpload1");
-    FileItem file2 = fileFields.get( "fileUpload2");
+    FileItem<?> file1 = fileFields.get( "fileUpload1");
+    FileItem<?> file2 = fileFields.get( "fileUpload2");
     if( fileFields.size() != 2 || file1 == null || file2 == null ) {
       throw new DirectTestFailedException( "Unexpected error receiving file fields");
     }
@@ -93,7 +93,7 @@ public class ManualFormUploadSupportTest {
 
 /*  
   @DirectFormPostMethod
-  public void djnform_test_simulateServerError( Map<String, String> formParameters, Map<String, FileItem> fileFields )  {
+  public void djnform_test_simulateServerError( Map<String, String> formParameters, Map<String, FileItem<?>> fileFields )  {
     assert formParameters != null;
     assert fileFields != null; 
     

--- a/directjngine-demo/src/main/java/com/softwarementors/extjs/djn/test/servlet/config/RegistryConfiguratorForTesting.java
+++ b/directjngine-demo/src/main/java/com/softwarementors/extjs/djn/test/servlet/config/RegistryConfiguratorForTesting.java
@@ -28,7 +28,7 @@ package com.softwarementors.extjs.djn.test.servlet.config;
 import java.lang.reflect.Method;
 import java.util.Map;
 
-import javax.servlet.ServletConfig;
+import jakarta.servlet.ServletConfig;
 
 import com.softwarementors.extjs.djn.StringUtils;
 import com.softwarementors.extjs.djn.api.RegisteredAction;

--- a/directjngine-demo/src/main/java/com/softwarementors/extjs/djn/test/servlet/ssm/WebContextManagerTest.java
+++ b/directjngine-demo/src/main/java/com/softwarementors/extjs/djn/test/servlet/ssm/WebContextManagerTest.java
@@ -25,8 +25,8 @@
 
 package com.softwarementors.extjs.djn.test.servlet.ssm;
 
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpSession;
 
 import com.softwarementors.extjs.djn.config.annotations.DirectMethod;
 import com.softwarementors.extjs.djn.servlet.ssm.WebContext;

--- a/directjngine/pom.xml
+++ b/directjngine/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonatype.directjngine</groupId>
     <artifactId>directjngine-parent</artifactId>
-    <version>2.2.11-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -52,13 +52,13 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.11.0</version>
+      <version>2.15.1</version>
     </dependency>
 
     <dependency>
-      <groupId>commons-fileupload</groupId>
-      <artifactId>commons-fileupload</artifactId>
-      <version>1.4</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
+      <version>2.0.0-M2</version>
     </dependency>
 
     <dependency>
@@ -126,9 +126,9 @@
     -->
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.0.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/router/RequestRouter.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/router/RequestRouter.java
@@ -32,8 +32,8 @@ import java.io.Reader;
 import java.io.Writer;
 import java.util.List;
 
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileUploadException;
+import org.apache.commons.fileupload2.core.FileItem;
+import org.apache.commons.fileupload2.core.FileUploadException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,7 +74,7 @@ public class RequestRouter {
     return new UploadFormPostRequestProcessor( this.registry, this.dispatcher, this.globalConfiguration);
   }
   
-  public void processUploadFormPostRequest(UploadFormPostRequestProcessor processor, List<FileItem> fileItems, Writer writer ) throws IOException {
+  public void processUploadFormPostRequest(UploadFormPostRequestProcessor processor, List<FileItem<?>> fileItems, Writer writer ) throws IOException {
     assert processor != null;
     
     processor.process( fileItems, writer );

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/standard/form/FormPostRequestData.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/standard/form/FormPostRequestData.java
@@ -28,7 +28,7 @@ package com.softwarementors.extjs.djn.router.processor.standard.form;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload2.core.FileItem;
 
 import com.softwarementors.extjs.djn.router.processor.standard.StandardRequestData;
 
@@ -45,9 +45,9 @@ public class FormPostRequestData extends StandardRequestData {
   // Make transient so that it is not serialized by our json processor
   transient private boolean isUpload;
   @NonNull transient private Map<String,String> formParameters;
-  @NonNull transient private Map<String, FileItem> fileFields; 
-  
-  public FormPostRequestData(String type, String action, String method, Long tid, boolean isUpload, Map<String, String> parameters, Map<String, FileItem> fileFields) {
+  @NonNull transient private Map<String, FileItem<?>> fileFields;
+
+  public FormPostRequestData(String type, String action, String method, Long tid, boolean isUpload, Map<String, String> parameters, Map<String, FileItem<?>> fileFields) {
     super( type, action, method, tid);
     
     assert parameters != null;
@@ -71,7 +71,7 @@ public class FormPostRequestData extends StandardRequestData {
     return this.formParameters;
   }
   
-  public Map<String, FileItem> getFileFields() {
+  public Map<String, FileItem<?>> getFileFields() {
     return this.fileFields;
   }
 }

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/standard/form/FormPostRequestProcessorBase.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/standard/form/FormPostRequestProcessorBase.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload2.core.FileItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +55,7 @@ public abstract class FormPostRequestProcessorBase extends StandardRequestProces
     super( registry, dispatcher, globalConfiguration);
   }
   
-  protected String process(Map<String,String> formParameters, Map<String, FileItem> fileFields) {
+  protected String process(Map<String,String> formParameters, Map<String, FileItem<?>> fileFields) {
     assert formParameters != null;
     assert fileFields != null;
      
@@ -75,7 +75,7 @@ public abstract class FormPostRequestProcessorBase extends StandardRequestProces
     return result;
   }
   
-  private static FormPostRequestData createRequestObject(Map<String, String> formParameters, Map<String, FileItem> fileFields) {
+  private static FormPostRequestData createRequestObject(Map<String, String> formParameters, Map<String, FileItem<?>> fileFields) {
     assert formParameters != null;
     assert fileFields != null;
     
@@ -134,8 +134,12 @@ public abstract class FormPostRequestProcessorBase extends StandardRequestProces
       return response;
     }
     finally {
-      for (FileItem fileItem : request.getFileFields().values()) {
-        fileItem.delete();
+      for (FileItem<?> fileItem : request.getFileFields().values()) {
+        try {
+          fileItem.delete();
+        } catch (java.io.IOException e) {
+          logger.warn("Failed to delete uploaded file: " + e.getMessage());
+        }
       }
     }
   }

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/standard/form/simple/SimpleFormPostRequestProcessor.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/standard/form/simple/SimpleFormPostRequestProcessor.java
@@ -31,7 +31,7 @@ import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload2.core.FileItem;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +60,7 @@ public class SimpleFormPostRequestProcessor extends FormPostRequestProcessorBase
     }
     Map<String, String> formParameters;
     formParameters = RequestProcessorUtils.getDecodedRequestParameters(requestString);    
-    String result = process(formParameters, new HashMap<String,FileItem>());
+    String result = process(formParameters, new HashMap<String,FileItem<?>>());
     writer.write( result );
     if( logger.isDebugEnabled() ) {
       logger.debug( "ResponseData data (SIMPLE FORM)=>" + result );

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/standard/form/upload/FileUploadException.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/standard/form/upload/FileUploadException.java
@@ -34,7 +34,7 @@ public class FileUploadException extends DirectJNgineException {
     super(message, cause);
   }
 
-  public static FileUploadException forFileUploadException( org.apache.commons.fileupload.FileUploadException cause ) {
+  public static FileUploadException forFileUploadException( org.apache.commons.fileupload2.core.FileUploadException cause ) {
     assert cause != null;
     
     // The FileUploadException raised by commons-fileupload usually hides an inner exception that is the real cause

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/standard/form/upload/UploadFormPostRequestProcessor.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/router/processor/standard/form/upload/UploadFormPostRequestProcessor.java
@@ -31,10 +31,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.commons.fileupload2.core.FileItem;
+import org.apache.commons.fileupload2.core.FileUploadException;
+import org.apache.commons.fileupload2.core.DiskFileItemFactory;
+import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletFileUpload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,16 +56,16 @@ public class UploadFormPostRequestProcessor extends FormPostRequestProcessorBase
     super( registry, dispatcher, globalConfiguration );
   }
 
-  public void process(List<FileItem> fileItems, Writer writer) throws IOException {
+  public void process(List<FileItem<?>> fileItems, Writer writer) throws IOException {
     assert fileItems != null;
     assert writer != null;
-    
+
     Map<String, String> formParameters = new HashMap<String,String>();
-    Map<String, FileItem> fileFields = new HashMap<String,FileItem>();
-    for( FileItem item : fileItems ) {
+    Map<String, FileItem<?>> fileFields = new HashMap<String,FileItem<?>>();
+    for( FileItem<?> item : fileItems ) {
       if (item.isFormField()) {
         formParameters.put( item.getFieldName(), item.getString());
-      } 
+      }
       else {
         fileFields.put( item.getFieldName(), item );
       }
@@ -98,10 +98,10 @@ public class UploadFormPostRequestProcessor extends FormPostRequestProcessorBase
     return result.toString();
   }
 
-  private static String getFileParametersLogString(Map<String, FileItem> fileFields) {
+  private static String getFileParametersLogString(Map<String, FileItem<?>> fileFields) {
     StringBuilder result = new StringBuilder();
-    for( Map.Entry<String,FileItem> entry : fileFields.entrySet() ) {
-      FileItem fileItem = entry.getValue();
+    for( Map.Entry<String,FileItem<?>> entry : fileFields.entrySet() ) {
+      FileItem<?> fileItem = entry.getValue();
       String fieldName = entry.getKey();
       result.append( fieldName );
       result.append( "=");
@@ -112,11 +112,11 @@ public class UploadFormPostRequestProcessor extends FormPostRequestProcessorBase
     return result.toString();
   }
 
-  public static ServletFileUpload createFileUploader(final long maxUploadSize) {
+  public static JakartaServletFileUpload createFileUploader(final long maxUploadSize) {
     // Create a factory for disk-based file items
-    DiskFileItemFactory factory = new DiskFileItemFactory();
+    DiskFileItemFactory.Builder builder = DiskFileItemFactory.builder();
     // Create a new file upload handler
-    ServletFileUpload upload = new ServletFileUpload(factory);
+    JakartaServletFileUpload upload = new JakartaServletFileUpload(builder.get());
 
     // Set upload handler limits
     upload.setSizeMax(maxUploadSize);

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/ServletRegistryConfigurator.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/ServletRegistryConfigurator.java
@@ -25,7 +25,7 @@
 
 package com.softwarementors.extjs.djn.servlet;
 
-import javax.servlet.ServletConfig;
+import jakarta.servlet.ServletConfig;
 
 import com.softwarementors.extjs.djn.api.Registry;
 

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/ServletUtils.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/ServletUtils.java
@@ -29,8 +29,8 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/ssm/SsmDispatcher.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/ssm/SsmDispatcher.java
@@ -28,8 +28,8 @@ package com.softwarementors.extjs.djn.servlet.ssm;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpSession;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/ssm/WebContext.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/ssm/WebContext.java
@@ -25,12 +25,12 @@
 
 package com.softwarementors.extjs.djn.servlet.ssm;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import com.softwarementors.extjs.djn.StringUtils;
 

--- a/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/ssm/WebContextManager.java
+++ b/directjngine/src/main/java/com/softwarementors/extjs/djn/servlet/ssm/WebContextManager.java
@@ -25,9 +25,9 @@
 
 package com.softwarementors.extjs.djn.servlet.ssm;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 

--- a/directjngine/src/test/java/com/softwarementors/extjs/djn/router/processor/standard/form/FormPostRequestProcessorBaseTest.java
+++ b/directjngine/src/test/java/com/softwarementors/extjs/djn/router/processor/standard/form/FormPostRequestProcessorBaseTest.java
@@ -31,7 +31,7 @@ import com.softwarementors.extjs.djn.api.Registry;
 import com.softwarementors.extjs.djn.config.GlobalConfiguration;
 import com.softwarementors.extjs.djn.gson.DefaultGsonBuilderConfigurator;
 import com.softwarementors.extjs.djn.router.dispatcher.Dispatcher;
-import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload2.core.FileItem;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -60,15 +60,15 @@ public class FormPostRequestProcessorBaseTest
   }
 
   @Test
-  public void validateTempFileRemoved() {
+  public void validateTempFileRemoved() throws Exception {
     Map<String,String> formParameters = new HashMap<String, String>();
     formParameters.put("extAction", "action");
     formParameters.put("extMethod", "method");
     formParameters.put("extType", "type");
     formParameters.put("extTID", "1");
     formParameters.put("extUpload", "true");
-    Map<String,FileItem> fileItems = new HashMap<String,FileItem>();
-    FileItem fileItem = Util.mockFileItem("field", "avalue");
+    Map<String,FileItem<?>> fileItems = new HashMap<String,FileItem<?>>();
+    FileItem<?> fileItem = Util.mockFileItem("field", "avalue");
     fileItems.put("field", fileItem);
     underTest.process(formParameters, fileItems);
     verify(fileItem).delete();

--- a/directjngine/src/test/java/com/softwarementors/extjs/djn/router/processor/standard/form/Util.java
+++ b/directjngine/src/test/java/com/softwarementors/extjs/djn/router/processor/standard/form/Util.java
@@ -24,7 +24,7 @@
  */
 package com.softwarementors.extjs.djn.router.processor.standard.form;
 
-import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload2.core.FileItem;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -35,8 +35,8 @@ public class Util
     //private constructor
   }
 
-  public static FileItem mockFileItem(String name, String value) {
-    FileItem fileItem = mock(FileItem.class);
+  public static FileItem<?> mockFileItem(String name, String value) {
+    FileItem<?> fileItem = mock(FileItem.class);
     when(fileItem.isFormField()).thenReturn(true);
     when(fileItem.getFieldName()).thenReturn(name);
     when(fileItem.getString()).thenReturn(value);

--- a/directjngine/src/test/java/com/softwarementors/extjs/djn/router/processor/standard/form/upload/UploadFormPostRequestProcessorTest.java
+++ b/directjngine/src/test/java/com/softwarementors/extjs/djn/router/processor/standard/form/upload/UploadFormPostRequestProcessorTest.java
@@ -33,7 +33,7 @@ import com.softwarementors.extjs.djn.config.GlobalConfiguration;
 import com.softwarementors.extjs.djn.gson.DefaultGsonBuilderConfigurator;
 import com.softwarementors.extjs.djn.router.dispatcher.Dispatcher;
 import com.softwarementors.extjs.djn.router.processor.standard.form.Util;
-import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload2.core.FileItem;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 

--- a/jenkins/Jenkinsfile-build
+++ b/jenkins/Jenkinsfile-build
@@ -3,7 +3,7 @@ library('jenkins-shared')
 
 mavenSnapshotPipeline(performSonarAnalysis: true,
     deployBranch: 'main',
-    mavenVersion: 'Maven 3.6.x',
+    mavenVersion: 'Maven 3.9.x',
     onSuccess: { build, env ->
       notifyChat(env: env, currentBuild: build, room: 'nxrm-notifications')
     },

--- a/jenkins/Jenkinsfile-release
+++ b/jenkins/Jenkinsfile-release
@@ -3,7 +3,7 @@ library('jenkins-shared')
 
 mavenReleasePipeline(
     deployBranch: 'main',
-    mavenVersion: 'Maven 3.6.x',
+    mavenVersion: 'Maven 3.9.x',
     mavenSettingsFile: 'rsc-private-settings', // internal publishing to rsc
     additionalReleaseProfiles: ['publish-central'], // public publishing to central
     onSuccess: { build, env ->

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.sonatype.directjngine</groupId>
   <artifactId>directjngine-parent</artifactId>
-  <version>2.2.11-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
 
@@ -31,8 +31,8 @@
   </licenses>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   
   <modules>
@@ -59,7 +59,7 @@
       <plugin>
         <groupId>com.sonatype.clm</groupId>
         <artifactId>clm-maven-plugin</artifactId>
-        <version>2.16.0-01</version>
+        <version>2.47.0-01</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Replace javax.servlet dependency with jakarta.servlet equivalent. Requires an upgrade of commons-fileupload in tandem.